### PR TITLE
typo for tensorflow 1.0 (tf.mul --> tf.multiply)

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -36,7 +36,7 @@ def loss(logits, labels, num_classes, head=None):
         softmax = tf.nn.softmax(logits) + epsilon
 
         if head is not None:
-            cross_entropy = -tf.reduce_sum(tf.mul(labels * tf.log(softmax),
+            cross_entropy = -tf.reduce_sum(tf.multiply(labels * tf.log(softmax),
                                            head), reduction_indices=[1])
         else:
             cross_entropy = -tf.reduce_sum(


### PR DESCRIPTION
The actual function in tensorflow 1.0 is tf.multiply and not tf.mul.